### PR TITLE
ttc-infra-gateway to 1.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: 1.0.26
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.6
+  version: 1.0.7


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.7