### PR TITLE
ttc-connectors-ranking to 1.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -25,3 +25,6 @@ dependencies:
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.10
+- name: ttc-connectors-ranking
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.11


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.11