### PR TITLE
ttc-connectors-processing to 1.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -30,4 +30,4 @@ dependencies:
   version: 1.0.11
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.10
+  version: 1.0.11


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.11