### PR TITLE
ttc-connectors-dummytwitter to 1.0.37

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.36
+  version: 1.0.37
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.37