### PR TITLE
ttc-infra-gateway to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.31
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.7
+  version: 1.0.9
 - name: ttc-query-campaign
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.19


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.9