### PR TITLE
ttc-connectors-ranking to 1.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 1.0.14
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.17
+  version: 1.0.18
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.11


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.18