### PR TITLE
ttc-dashboard-ui to 0.0.35

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -33,4 +33,4 @@ dependencies:
   version: 1.0.16
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.34
+  version: 0.0.35


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.35